### PR TITLE
Update ember-cli and use attribute lifecycle hook

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,6 +10,5 @@ dist/
 .npmignore
 **/.gitkeep
 bower.json
-ember-cli-build.js
 Brocfile.js
 testem.json

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,3 +1,3 @@
 {
-  "ignore_dirs": ["tmp"]
+  "ignore_dirs": ["tmp", "dist"]
 }

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ To pass parameters to action you can use:
 Confirmed that it works with release, beta, canary Ember versions:
 
 - 2.0.2
-- 2.1.0-beta.4
-- 2.2.0-canary+77f6fc86
+- 2.1.1
+- 2.2.0
+- 2.3.0-beta.3
+- 2.4.0-canary+c8ce20b704
 
 # Installation
 

--- a/addon/mixins/link-action.js
+++ b/addon/mixins/link-action.js
@@ -5,7 +5,7 @@ export default Ember.Mixin.create({
     this.sendAction('invokeAction');
   },
 
-  init() {
+  didInitAttrs() {
     this._super(...arguments);
 
     // Map desired event name to invoke function
@@ -15,7 +15,6 @@ export default Ember.Mixin.create({
       this.on(eventName, this, this._sendInvokeAction);
     }
 
-    this.on(eventName, this, this._invoke);
   },
 
   willDestroyElement() {

--- a/bower.json
+++ b/bower.json
@@ -2,17 +2,14 @@
   "name": "ember-link-action",
   "dependencies": {
     "ember": "2.0.2",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.9",
-    "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.18",
+    "ember-cli-shims": "0.0.6",
+    "ember-cli-test-loader": "0.2.1",
+    "ember-load-initializers": "0.1.7",
+    "ember-qunit": "0.4.16",
+    "ember-qunit-notifications": "0.1.0",
+    "ember-resolver": "~0.1.20",
     "jquery": "^1.11.3",
-    "loader.js": "ember-cli/loader.js#3.2.1",
-    "qunit": "~1.18.0"
-  },
-  "resolutions": {
-    "ember": "2.0.2"
+    "loader.js": "ember-cli/loader.js#3.4.0",
+    "qunit": "~1.20.0"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,3 +1,4 @@
+/*jshint node:true*/
 module.exports = {
   scenarios: [
     {

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,3 +1,4 @@
+/*jshint node:true*/
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,8 +1,9 @@
+/*jshint node:true*/
 /* global require, module */
-var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberApp(defaults, {
+  var app = new EmberAddon(defaults, {
     // Add options here
   });
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,10 +7,6 @@ module.exports = function(defaults) {
     // Add options here
   });
 
-  app.import({
-    test: 'bower_components/ember/ember-template-compiler.js'
-  });
-
   /*
     This build file specifes the options for the dummy test app of this
     addon, located in `/tests/dummy`

--- a/package.json
+++ b/package.json
@@ -21,29 +21,30 @@
   "author": "Daniel 'Kuzirashi' Kmak",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.1.2",
-    "ember-cli": "1.13.8",
-    "ember-cli-app-version": "0.5.0",
+    "broccoli-asset-rev": "^2.2.0",
+    "ember-cli": "1.13.13",
+    "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "^1.0.1",
-    "ember-cli-htmlbars": "0.7.9",
-    "ember-cli-htmlbars-inline-precompile": "0.3.1",
-    "ember-cli-ic-ajax": "0.2.1",
+    "ember-cli-dependency-checker": "^1.1.0",
+    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-ic-ajax": "0.2.4",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.0.0",
-    "ember-cli-release": "0.2.3",
-    "ember-cli-sri": "^1.0.3",
+    "ember-cli-qunit": "^1.0.4",
+    "ember-cli-release": "0.2.8",
+    "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-disable-proxy-controllers": "^1.0.0",
-    "ember-export-application-global": "^1.0.3",
-    "ember-try": "0.0.6"
+    "ember-disable-proxy-controllers": "^1.0.1",
+    "ember-export-application-global": "^1.0.4",
+    "ember-try": "~0.0.8",
+    "handlebars": "^1.3.0"
   },
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.3"
+    "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/testem.json
+++ b/testem.json
@@ -6,6 +6,7 @@
     "PhantomJS"
   ],
   "launch_in_dev": [
-    "PhantomJS"
+    "PhantomJS",
+    "Chrome"
   ]
 }

--- a/tests/acceptance/link-action-test.js
+++ b/tests/acceptance/link-action-test.js
@@ -1,20 +1,12 @@
 /* global getRegistry */
 
 import Ember from 'ember';
-import { module, test } from 'qunit';
-import startApp from '../../tests/helpers/start-app';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
 const precompileTemplate = Ember.HTMLBars.compile;
 
-module('Acceptance | link action', {
-  beforeEach() {
-    this.application = startApp();
-  },
-
-  afterEach() {
-    Ember.run(this.application, 'destroy');
-  }
-});
+moduleForAcceptance('Acceptance | link action');
 
 Ember.Test.registerHelper('getRegistry', app => app.registry);
 

--- a/tests/acceptance/link-action-test.js
+++ b/tests/acceptance/link-action-test.js
@@ -3,8 +3,7 @@
 import Ember from 'ember';
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
-
-const precompileTemplate = Ember.HTMLBars.compile;
+import hbs from 'htmlbars-inline-precompile';
 
 moduleForAcceptance('Acceptance | link action');
 
@@ -23,11 +22,11 @@ test('clicking {{link-to}} with closure action specified correctly transition to
     }
   }));
 
-  registry.register('template:link-action', precompileTemplate(`
+  registry.register('template:link-action', hbs`
     {{#link-to 'other-route' invokeAction=(action 'testAction')}}
       Link to other route
     {{/link-to}}
-  `));
+  `);
 
   visit('/link-action');
 
@@ -51,11 +50,11 @@ test('clicking {{link-to}} with action name specified correctly transition to ot
     }
   }));
 
-  registry.register('template:link-action', precompileTemplate(`
+  registry.register('template:link-action', hbs`
     {{#link-to 'other-route' invokeAction='testAction'}}
       Link to other route
     {{/link-to}}
-  `));
+  `);
 
   visit('/link-action');
 
@@ -84,11 +83,11 @@ test('action parameters can be passed to invoked action', assert => {
     }
   }));
 
-  registry.register('template:link-action', precompileTemplate(`
+  registry.register('template:link-action', hbs`
     {{#link-to 'other-route' invokeAction=(action 'testAction' 'value1' 'value2')}}
       Link to other route
     {{/link-to}}
-  `));
+  `);
 
   visit('/link-action');
 

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,12 +3,14 @@ import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
+let App;
+
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-let App = Ember.Application.extend({
+App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver: Resolver
+  Resolver
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import config from './config/environment';
 
-var Router = Ember.Router.extend({
+const Router = Ember.Router.extend({
   location: config.locationType
 });
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,0 +1,3 @@
+<h2 id="title">Welcome to Ember</h2>
+
+{{outlet}}

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default function destroyApp(application) {
+  Ember.run(application, 'destroy');
+}

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,0 +1,23 @@
+import { module } from 'qunit';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+
+export default function(name, options = {}) {
+  module(name, {
+    beforeEach() {
+      this.application = startApp();
+
+      if (options.beforeEach) {
+        options.beforeEach.apply(this, arguments);
+      }
+    },
+
+    afterEach() {
+      destroyApp(this.application);
+
+      if (options.afterEach) {
+        options.afterEach.apply(this, arguments);
+      }
+    }
+  });
+}

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,7 +1,7 @@
 import Resolver from 'ember/resolver';
 import config from '../../config/environment';
 
-var resolver = Resolver.create();
+const resolver = Resolver.create();
 
 resolver.namespace = {
   modulePrefix: config.modulePrefix,

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -8,7 +8,7 @@ export default function startApp(attrs) {
   let attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
-  Ember.run(function() {
+  Ember.run(() => {
     application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/tests/index.html
+++ b/tests/index.html
@@ -18,13 +18,14 @@
     {{content-for 'test-head-footer'}}
   </head>
   <body>
-
     {{content-for 'body'}}
     {{content-for 'test-body'}}
+
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/dummy.js"></script>
-    <script src="testem.js"></script>
+    <script src="testem.js" integrity=""></script>
+    <script src="assets/tests.js"></script>
     <script src="assets/test-loader.js"></script>
 
     {{content-for 'body-footer'}}


### PR DESCRIPTION
This PR includes;

1. Update addon to ember-cli 1.13.13
2. Import the compiler directly in the test
3. Move the `init()` work to the `didInitAttrs()` hook
4. Update Compatibility list

The main reason I started this PR was for the `didInitAttrs()` hook, everything else just came along for the ride. :)

By using the `didInitAttrs()` hook, it ensures that the `invokeAction` attribute is available. Probably not super important but it’s one of those new lifecycle hooks available in ember 1.13.