### PR TITLE
didInitAttrs is deprecated in Ember 2.6

### DIFF
--- a/addon/mixins/link-action.js
+++ b/addon/mixins/link-action.js
@@ -5,7 +5,7 @@ export default Ember.Mixin.create({
     this.sendAction('invokeAction');
   },
 
-  didInitAttrs() {
+  init() {
     this._super(...arguments);
 
     // Map desired event name to invoke function


### PR DESCRIPTION
More info: http://emberjs.com/deprecations/v2.x/#toc_ember-component-didinitattrs.