### PR TITLE
Handle closure actions

### DIFF
--- a/addon/mixins/link-action.js
+++ b/addon/mixins/link-action.js
@@ -15,7 +15,11 @@ export default Mixin.create({
   },
 
   _sendInvokeAction() {
-    this.sendAction('invokeAction');
+    if (typeof(this.invokeAction) === 'function') {
+      this.invokeAction();
+    } else if (typeof(this.invokeAction) === 'string') {
+      this.sendAction('invokeAction');
+    }
   },
   _attachActionEvent() {
     this.on(this.get('eventName'), this, this._sendInvokeAction);

--- a/tests/unit/mixins/link-action-test.js
+++ b/tests/unit/mixins/link-action-test.js
@@ -13,7 +13,7 @@ module('Unit | Mixin | link action', function() {
     assert.ok(subject);
   });
 
-  test('_sendInvokeAction sends `invokeAction` action', function(assert) {
+  test('_sendInvokeAction sends `invokeAction` string action', function(assert) {
     assert.expect(2);
 
     const EXPECTED_ACTION_NAME = 'invokeAction';
@@ -25,6 +25,20 @@ module('Unit | Mixin | link action', function() {
         assert.equal(actionName, EXPECTED_ACTION_NAME);
       }
     });
+
+    subject.invokeAction = EXPECTED_ACTION_NAME;
+    subject._sendInvokeAction();
+  });
+
+  test('_sendInvokeAction sends `invokeAction` closure action', function(assert) {
+    assert.expect(1);
+
+    const LinkActionObject = EmberObject.extend(LinkActionMixin);
+    const subject = LinkActionObject.create();
+
+    subject.invokeAction = () => {
+      assert.ok(true, 'closure action was called');
+    };
 
     subject._sendInvokeAction();
   });


### PR DESCRIPTION
Handle closure actions but also continue to handle string actions via sendAction [DEPRECATED].

Allows preventing the following deprecation warning:
```
VM2169 vendor.js:25085 DEPRECATION: You called <app@component:link-to::ember406>.sendAction("invokeAction") but Component#sendAction is deprecated. Please use closure actions instead. [deprecation id: ember-component.send-action] See https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action for more details.
        at logDeprecationStackTrace (http://localhost:4200/assets/vendor.js:25071:29)
        at HANDLERS.(anonymous function) (http://localhost:4200/assets/vendor.js:25173:17)
        at raiseOnDeprecation (http://localhost:4200/assets/vendor.js:25095:17)
        at HANDLERS.(anonymous function) (http://localhost:4200/assets/vendor.js:25173:17)
        at invoke (http://localhost:4200/assets/vendor.js:25182:17)
        at deprecate (http://localhost:4200/assets/vendor.js:25154:34)
        at Class.sendAction (http://localhost:4200/assets/vendor.js:66419:49)
        at Class._sendInvokeAction (http://localhost:4200/assets/vendor.js:218714:14)
        at sendEvent (http://localhost:4200/assets/vendor.js:51258:20)
```